### PR TITLE
Feat/#22 카카오 로그인 구현

### DIFF
--- a/src/apis/auth/kakao.ts
+++ b/src/apis/auth/kakao.ts
@@ -1,0 +1,8 @@
+import api from '@/apis/base/axios';
+
+const getKakaoLoginUrl = async () => {
+  const { data } = await api.get<string>('/api/auth/kakao/login-url');
+  return data;
+};
+
+export { getKakaoLoginUrl };

--- a/src/apis/base/axios.ts
+++ b/src/apis/base/axios.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 const instance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
+  withCredentials: true,
   timeout: 5000,
 });
 

--- a/src/apis/users/me.ts
+++ b/src/apis/users/me.ts
@@ -1,0 +1,11 @@
+import api from '@/apis/base/axios';
+
+import type { MeResponse } from './types';
+
+const getMe = async () => {
+  const { data } = await api.get<MeResponse>('/users/me');
+  return data;
+};
+
+export { getMe };
+export type { MeResponse };

--- a/src/apis/users/types.ts
+++ b/src/apis/users/types.ts
@@ -1,0 +1,6 @@
+type MeResponse = {
+  userId: number;
+  nickname: string;
+};
+
+export type { MeResponse };

--- a/src/components/layout/MainHeader/LoginButton/index.tsx
+++ b/src/components/layout/MainHeader/LoginButton/index.tsx
@@ -1,9 +1,31 @@
+import { useState } from 'react';
+
+import { getKakaoLoginUrl } from '@/apis/auth/kakao';
 import { HEADER_ACTION_TEXTS } from '@/components/layout/MainHeader/constants';
 
 function LoginButton() {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleLogin = async () => {
+    if (isLoading) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const loginUrl = await getKakaoLoginUrl();
+      window.location.href = loginUrl;
+    } catch (error) {
+      console.error('카카오 로그인 URL 조회 실패', error);
+      setIsLoading(false);
+    }
+  };
+
   return (
     <button
       type="button"
+      onClick={handleLogin}
+      disabled={isLoading}
       className="typo-16-medium md:typo-20-medium lg:typo-20-medium ml-auto rounded-lg bg-green-500 px-5 py-2 text-white"
     >
       {HEADER_ACTION_TEXTS.LOGIN}

--- a/src/components/layout/MainHeader/index.tsx
+++ b/src/components/layout/MainHeader/index.tsx
@@ -20,11 +20,12 @@ function Header() {
         }
 
         setDisplayName(me.nickname || null);
-      } catch {
+      } catch (error) {
         if (!mounted) {
           return;
         }
 
+        console.error('사용자 정보 조회에 실패했습니다:', error);
         setDisplayName(null);
       }
     };

--- a/src/components/layout/MainHeader/index.tsx
+++ b/src/components/layout/MainHeader/index.tsx
@@ -1,10 +1,41 @@
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
-import { Logo } from '@/assets/images';
+import { getMe } from '@/apis/users/me';
+import { ImgProfile, Logo } from '@/assets/images';
 
 import LoginButton from './LoginButton';
 
 function Header() {
+  const [displayName, setDisplayName] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const fetchMe = async () => {
+      try {
+        const me = await getMe();
+        if (!mounted) {
+          return;
+        }
+
+        setDisplayName(me.nickname || null);
+      } catch {
+        if (!mounted) {
+          return;
+        }
+
+        setDisplayName(null);
+      }
+    };
+
+    fetchMe();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
   return (
     <header className="relative h-20 w-full bg-white shadow-xl">
       <nav className="layout-content flex h-full w-full items-center px-5">
@@ -17,7 +48,16 @@ function Header() {
             />
           </Link>
         </h1>
-        <LoginButton />
+        {displayName ? (
+          <div className="ml-auto flex items-center gap-2">
+            <ImgProfile className="h-7 w-7 md:h-8 md:w-8" aria-hidden="true" />
+            <p className="typo-16-medium md:typo-20-medium lg:typo-20-medium text-grey-800">
+              {displayName}
+            </p>
+          </div>
+        ) : (
+          <LoginButton />
+        )}
       </nav>
     </header>
   );

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,7 +1,7 @@
-import type { ClassValue } from 'clsx'
-import { clsx } from 'clsx'
-import { twMerge } from 'tailwind-merge'
+import type { ClassValue } from 'clsx';
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #22

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [ ] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**카카오 API 연결**
- 백에서 httpOnly 설정 -> axios에 withCredentials 추가
- 쿠키로 저장

**마이프로필 연결**
- 사용자 API 연결
- 로그인 후 로그인 버튼 대신 사용자 이름이 나오도록 구현

### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
