### PR TITLE
Fix/#41 Chat 카운트 타이밍 수정

### DIFF
--- a/src/components/chat/Header/types.ts
+++ b/src/components/chat/Header/types.ts
@@ -1,5 +1,7 @@
+import type { ReactNode } from 'react';
+
 type ChatHeaderProps = {
-  title: string;
+  title: ReactNode;
   subtitle: string;
   statusLabel: string;
   audienceLabel: string;

--- a/src/components/common/Loading/index.tsx
+++ b/src/components/common/Loading/index.tsx
@@ -1,0 +1,36 @@
+import type { CSSProperties } from 'react';
+
+import type { LoadingProps } from './types';
+
+type LoadingStyle = CSSProperties & {
+  '--bounce-translate-y'?: string;
+};
+
+export const Loading = ({ size = 16, color = 'white' }: LoadingProps) => {
+  const dotSize = size * 0.25;
+  const gap = size * 0.15;
+  const containerStyle: LoadingStyle = {
+    '--bounce-translate-y': `-${size * 0.25}px`,
+    gap: `${gap}px`,
+    height: `${size}px`,
+  };
+
+  return (
+    <div
+      className="inline-flex items-center justify-center"
+      style={containerStyle}
+    >
+      {[0, 1, 2].map((i) => (
+        <div
+          key={i}
+          className="loading-dot rounded-full"
+          style={{
+            width: `${dotSize}px`,
+            height: `${dotSize}px`,
+            backgroundColor: color,
+          }}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/common/Loading/types.ts
+++ b/src/components/common/Loading/types.ts
@@ -1,0 +1,4 @@
+export type LoadingProps = {
+  size?: number;
+  color?: string;
+};

--- a/src/pages/ChatPage/index.tsx
+++ b/src/pages/ChatPage/index.tsx
@@ -16,7 +16,9 @@ import type { ChatMessagePayload } from '@/types/chat';
 
 const EMPTY_MESSAGES: ChatMessage[] = [];
 
-const getChatMessageFromPayload = (payload: ChatMessagePayload): ChatMessage => ({
+const getChatMessageFromPayload = (
+  payload: ChatMessagePayload
+): ChatMessage => ({
   id: payload.messageId,
   sender: 'sender',
   text: payload.content,
@@ -26,7 +28,7 @@ const getChatMessageFromPayload = (payload: ChatMessagePayload): ChatMessage => 
 
 const getFallbackChatRoom = (symbol: string) => ({
   symbol,
-  name: symbol,
+  name: '',
   market: '',
   count: 0,
 });
@@ -172,6 +174,39 @@ function ChatPage() {
       mounted = false;
     };
   }, [symbol]);
+
+  useEffect(() => {
+    let mounted = true;
+    let timeoutId: number | undefined;
+
+    const refreshChatRoomCount = async () => {
+      if (!symbol || !isConnected) {
+        return;
+      }
+
+      try {
+        const count = await getChatRoomCount(symbol);
+        if (!mounted) {
+          return;
+        }
+
+        setAudienceCount(count.count);
+      } catch {
+        // count 갱신 실패 시 무시
+      }
+    };
+
+    if (symbol && isConnected) {
+      timeoutId = window.setTimeout(refreshChatRoomCount, 500);
+    }
+
+    return () => {
+      mounted = false;
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [symbol, isConnected]);
 
   const handleSend = () => {
     const trimmed = input.trim();

--- a/src/pages/ChatPage/index.tsx
+++ b/src/pages/ChatPage/index.tsx
@@ -11,6 +11,7 @@ import ChatFooter from '@/components/chat/Footer';
 import ChatHeader from '@/components/chat/Header';
 import ChatMessageList from '@/components/chat/MessageList';
 import type { ChatMessage } from '@/components/chat/MessageList/types';
+import { Loading } from '@/components/common/Loading';
 import { useChatSocket } from '@/hooks/useChatSocket';
 import type { ChatMessagePayload } from '@/types/chat';
 
@@ -49,6 +50,7 @@ function ChatPage() {
     market: fallbackRoom.market,
   });
   const [audienceCount, setAudienceCount] = useState(fallbackRoom.count);
+  const [isRoomInfoLoading, setIsRoomInfoLoading] = useState(true);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const messages = messagesBySymbol[symbol] ?? EMPTY_MESSAGES;
   const applyFallbackState = (targetSymbol: string) => {
@@ -143,6 +145,10 @@ function ChatPage() {
       }
 
       try {
+        if (mounted) {
+          setIsRoomInfoLoading(true);
+        }
+
         const [info, count, history] = await Promise.all([
           getChatRoomInfo(symbol),
           getChatRoomCount(symbol),
@@ -165,6 +171,10 @@ function ChatPage() {
         }
 
         applyFallbackState(symbol);
+      } finally {
+        if (mounted) {
+          setIsRoomInfoLoading(false);
+        }
       }
     };
 
@@ -230,8 +240,16 @@ function ChatPage() {
       <section className="mx-auto flex min-h-screen w-full max-w-300 flex-col bg-white md:min-h-dvh">
         <div className="flex min-h-screen flex-1 flex-col bg-white">
           <ChatHeader
-            title={roomInfo.name}
-            subtitle={`${roomInfo.market} ${roomInfo.symbol}`}
+            title={
+              isRoomInfoLoading ? (
+                <Loading size={18} color="var(--color-grey-300)" />
+              ) : (
+                roomInfo.name || symbol
+              )
+            }
+            subtitle={
+              isRoomInfoLoading ? '' : `${roomInfo.market} ${roomInfo.symbol}`
+            }
             statusLabel={isConnected ? '실시간 채팅' : '채팅 연결 중'}
             audienceLabel={`${audienceCount}명 접속중`}
             onBack={() => navigate(-1)}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #41

## 체크 사항

- [x] UI 동작 및 레이아웃 확인
- [x] 콘솔 로그/에러 없음
- [x] 기능 정상 동작
- [x] 팀 컨벤션에 맞게 구현했는지

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- ChatPage 진입 시 채팅방 api를 가져오는 흐름을 개선했습니다. 
- 초기 렌더에서 채팅방 정보, 카운트, 히스토리를 동시에 불러오고 웹소켓 연결이 완료된 시점에서 카운트를 한 번 더 재조회하도록 했습니다. 
- 이를 통해 서버 접속 집계가 반영된 최신 접속자 수가 프론트에 표시되도록 하고, 채팅방 이름을 가져오는 동안에는 헤더에 로딩 스피너를 보여주도록 처리했습니다. 


### 스크린샷 (선택)

### 추가한 라이브러리 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
